### PR TITLE
Make API URL configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-API_URL=http://localhost:3002
+VITE_API_URL=http://localhost:3002
+

--- a/src/entities/playlist/api/index.ts
+++ b/src/entities/playlist/api/index.ts
@@ -1,10 +1,11 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react"
-import type { Playlist } from "@/shared/types"
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import type { Playlist } from '@/shared/types'
+import { API_URL } from '@/shared/config'
 
 export const playlistsApi = createApi({
   reducerPath: "playlistsApi",
   baseQuery: fetchBaseQuery({
-    baseUrl: "/api/playlists",
+    baseUrl: `${API_URL}/api/playlists`,
     prepareHeaders: (headers, { getState }) => {
       const token = (getState() as any).auth.token
       if (token) {

--- a/src/entities/track/api/index.ts
+++ b/src/entities/track/api/index.ts
@@ -1,10 +1,11 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react"
-import type { Track } from "@/shared/types"
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import type { Track } from '@/shared/types'
+import { API_URL } from '@/shared/config'
 
 export const tracksApi = createApi({
   reducerPath: "tracksApi",
   baseQuery: fetchBaseQuery({
-    baseUrl: `http://localhost:3002/api/tracks`,
+    baseUrl: `${API_URL}/api/tracks`,
     prepareHeaders: (headers, { getState }) => {
       const token = (getState() as any).auth.token
       if (token) {

--- a/src/features/auth/api/index.ts
+++ b/src/features/auth/api/index.ts
@@ -1,5 +1,6 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react"
-import type { User } from "@/shared/types"
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import type { User } from '@/shared/types'
+import { API_URL } from '@/shared/config'
 
 interface LoginRequest {
   email: string
@@ -18,7 +19,7 @@ interface LoginResponse {
 }
 
 const baseQuery = fetchBaseQuery({
-  baseUrl: `http://localhost:3002/api/auth`,
+  baseUrl: `${API_URL}/api/auth`,
   prepareHeaders: (headers, { getState }) => {
     const token = (getState() as any).auth.token
     if (token) {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -6,8 +6,9 @@ import { ExitToApp, CloudUpload, Save } from "@mui/icons-material"
 import { Sidebar } from "@/widgets/sidebar"
 import { MobileHeader } from "@/widgets/mobile-header"
 import { MobileNavigation } from "@/widgets/mobile-navigation"
-import { useAppSelector, useAppDispatch } from "@/shared/hooks"
-import { selectCurrentUser, performLogout } from "@/features/auth"
+import { useAppSelector, useAppDispatch } from '@/shared/hooks'
+import { selectCurrentUser, performLogout } from '@/features/auth'
+import { API_URL } from '@/shared/config'
 import { useNavigate } from "react-router-dom"
 
 export default function ProfilePage() {
@@ -52,7 +53,7 @@ export default function ProfilePage() {
         const formData = new FormData()
         formData.append('avatar', avatarFile)
         
-        const response = await fetch('http://localhost:3002/api/upload/avatar', {
+        const response = await fetch(`${API_URL}/api/upload/avatar`, {
           method: 'POST',
           headers: {
             'Authorization': `Bearer ${localStorage.getItem('token')}`
@@ -69,7 +70,7 @@ export default function ProfilePage() {
       }
       
       // Обновляем профиль
-      const updateResponse = await fetch('http://localhost:3002/api/auth/profile', {
+      const updateResponse = await fetch(`${API_URL}/api/auth/profile`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/src/pages/upload-track/ui/UploadTrackPage.tsx
+++ b/src/pages/upload-track/ui/UploadTrackPage.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import React, { useState, useCallback } from "react"
-import { useNavigate } from "react-router-dom"
+import React, { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   Box,
   Typography,
@@ -30,11 +30,12 @@ import {
   Delete as DeleteIcon,
   PlayArrow
 } from "@mui/icons-material"
-import { Sidebar } from "@/widgets/sidebar"
-import { MobileHeader } from "@/widgets/mobile-header"
-import { MobileNavigation } from "@/widgets/mobile-navigation"
-import { useCreateTrackMutation } from "@/entities/track/api"
-import type { Track } from "@/shared/types"
+import { Sidebar } from '@/widgets/sidebar'
+import { MobileHeader } from '@/widgets/mobile-header'
+import { MobileNavigation } from '@/widgets/mobile-navigation'
+import { useCreateTrackMutation } from '@/entities/track/api'
+import type { Track } from '@/shared/types'
+import { API_URL } from '@/shared/config'
 
 const genres = [
   "Pop",
@@ -291,7 +292,7 @@ export default function UploadTrackPage() {
       const audioFormData = new FormData()
       audioFormData.append('audio', audioFile)
       
-      const audioResponse = await fetch('http://localhost:3002/api/upload/audio', {
+      const audioResponse = await fetch(`${API_URL}/api/upload/audio`, {
         method: 'POST',
         body: audioFormData
       })
@@ -309,7 +310,7 @@ export default function UploadTrackPage() {
         const coverFormData = new FormData()
         coverFormData.append('image', coverFile)
         
-        const coverResponse = await fetch('http://localhost:3002/api/upload/image', {
+        const coverResponse = await fetch(`${API_URL}/api/upload/image`, {
           method: 'POST',
           body: coverFormData
         })

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,0 +1,2 @@
+export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3002'
+

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,29 @@
-import { defineConfig } from "vite"
+import { defineConfig, loadEnv } from "vite"
 import react from "@vitejs/plugin-react"
 import path from "path"
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
-  server: {
-    port: 3000,
-    open: true,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3002',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
       },
     },
-  },
-  build: {
-    outDir: "dist",
-    sourcemap: true,
-  },
+    server: {
+      port: 3000,
+      open: true,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL || 'http://localhost:3002',
+          changeOrigin: true,
+        },
+      },
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: true,
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- add `VITE_API_URL` example
- use `API_URL` constant for fetch requests and RTK query bases
- expose variable via `vite.config.ts`
- update types for `ImportMetaEnv`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config "airbnb")*
- `npm run type-check` *(fails with several TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68400161770083319ecbb08f2b6399cc