### PR TITLE
Fix duplicate CORS headers

### DIFF
--- a/api-server.cjs
+++ b/api-server.cjs
@@ -67,14 +67,6 @@ function saveFileToPublic(file, subDir = '') {
   }
 }
 
-function setCORSHeaders(res) {
-  // Ensure headers are written only once to avoid duplicate values
-  if (!res.headersSent) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,PATCH,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  }
-}
 
 function sendJSON(res, statusCode, data) {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
@@ -82,7 +74,6 @@ function sendJSON(res, statusCode, data) {
 }
 
 const server = http.createServer((req, res) => {
-  setCORSHeaders(res);
 
   if (req.method === 'OPTIONS') {
     res.writeHead(200);


### PR DESCRIPTION
## Summary
- remove CORS headers from api server to avoid duplicates when proxied

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "airbnb")*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_684014b147348331b118df0d726f7742